### PR TITLE
Including repository misc files and editor preferences

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,html}]
+charset = utf-8
+indent_style = tab
+indent_size = 2
+
+[*.{js}]
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules
+npm-debug.log


### PR DESCRIPTION
Inclusion of `.gitignore`, `.editorconfig` preferences and `.gitattributes` - CRLF option for users missing `core.autocrlf` on git.